### PR TITLE
Be able to specify only a destination for INPUT rules

### DIFF
--- a/templates/01-input-localrules-policy.j2
+++ b/templates/01-input-localrules-policy.j2
@@ -7,6 +7,29 @@
 {% set iptables_dport = '' %}
 {% endif -%}
 
--A INPUT -p {{ rule.protocol|default('tcp') }} --source {{ rule.source|default('0.0.0.0/0') }} {{ iptables_dport }} -j ACCEPT
+# Note that the conditional is flipped from how we handle the dport, this is
+# because previously we set a default to tcp if the protocol was undefined. If
+# we want to set ip-based INPUT rules (for all protocols), we need to
+# explicitly set rule.protocol to None
+{% if rule.protocol == '' -%}
+{% set iptables_protocol = '' %}
+{% else %}
+{% set iptables_protocol = '-p ' + rule.protocol %}
+{% endif %}
+
+{% if rule.source == '' %}
+{% set iptables_source = '' %}
+{% else %}
+{% set iptables_source = '--source ' + rule.source|default('0.0.0.0/0') %}
+{% endif %}
+
+# This is a 'new' conditional, so we can use the same pattern as above
+{% if rule.destination is defined -%}
+{% set iptables_destination = '--destination ' + rule.destination %}
+{% else %}
+{% set iptables_destination = '' %}
+{% endif %}
+
+-A INPUT {{ iptables_protocol }} {{ iptables_source }} {{ iptables_dport }}  {{ iptables_destination }} -j ACCEPT
 
 {% endfor %}

--- a/templates/01-input-localrules-policy.j2
+++ b/templates/01-input-localrules-policy.j2
@@ -7,23 +7,28 @@
 {% set iptables_dport = '' %}
 {% endif -%}
 
-# Note that the conditional is flipped from how we handle the dport, this is
-# because previously we set a default to tcp if the protocol was undefined. If
-# we want to set ip-based INPUT rules (for all protocols), we need to
-# explicitly set rule.protocol to None
-{% if rule.protocol == '' -%}
+{# Note that the conditional is flipped from how we handle the dport, this is
+ because previously we set a default to tcp if the protocol was undefined. If
+ we want to set ip-based INPUT rules (for all protocols), we need to
+ explicitly set rule.protocol to None
+#}
+{% if rule.protocol is not defined -%}
+{% set iptables_protocol = '-p ' + 'tcp' %}
+{% elif rule.protocol == '' %}
 {% set iptables_protocol = '' %}
 {% else %}
-{% set iptables_protocol = '-p ' + rule.protocol|default('tcp') %}
+{% set iptables_protocol = '-p ' + rule.protocol %}
 {% endif %}
 
-{% if rule.source == '' %}
+{% if rule.source is not defined -%}
+{% set iptables_source = '--source ' + '0.0.0.0/0' %}
+{% elif rule.source == '' %}
 {% set iptables_source = '' %}
 {% else %}
-{% set iptables_source = '--source ' + rule.source|default('0.0.0.0/0') %}
+{% set iptables_source = '--source ' + rule.source %}
 {% endif %}
 
-# This is a 'new' conditional, so we can use the same pattern as above
+{# This is a 'new' conditional, so we can use the same pattern as above #}
 {% if rule.destination is defined -%}
 {% set iptables_destination = '--destination ' + rule.destination %}
 {% else %}

--- a/templates/01-input-localrules-policy.j2
+++ b/templates/01-input-localrules-policy.j2
@@ -14,7 +14,7 @@
 {% if rule.protocol == '' -%}
 {% set iptables_protocol = '' %}
 {% else %}
-{% set iptables_protocol = '-p ' + rule.protocol %}
+{% set iptables_protocol = '-p ' + rule.protocol|default('tcp') %}
 {% endif %}
 
 {% if rule.source == '' %}


### PR DESCRIPTION
We need this when we know the destination address, but not the source,
but still want to accept traffic. For example: conntrackd uses a
multicast address to synchronize its traffic. You can use it by doing
the following in the host_vars:

```
vars:
  iptables_local_input_rules:
    - destination: 225.0.0.50
      protocol: ''
      source: ''
```